### PR TITLE
chore: updating dependencies

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   userver-nginx-proxy:
     container_name: userver-nginx-proxy
-    image: nginxproxy/nginx-proxy:1.2-alpine
+    image: nginxproxy/nginx-proxy:1.5-alpine
     env_file:
       - nginx-proxy/.env
     ports:
@@ -21,7 +21,7 @@ services:
 
   userver-letsencrypt:
     container_name: userver-letsencrypt
-    image: nginxproxy/acme-companion:2.2
+    image: nginxproxy/acme-companion:2.3
     depends_on:
       - userver-nginx-proxy
     env_file:
@@ -34,7 +34,7 @@ services:
 
   userver-monitor:
     container_name: userver-monitor
-    image: ferdn4ndo/docker-containers-monitor:1.0.0
+    image: ferdn4ndo/docker-containers-monitor:1.0.1
     env_file:
       - ./monitor/.env
     volumes:
@@ -42,7 +42,7 @@ services:
 
   userver-whoami:
     container_name: userver-whoami
-    image: traefik/whoami:v1.8
+    image: traefik/whoami:v1.10
     expose:
       - 80
     env_file:

--- a/monitor/.env.template
+++ b/monitor/.env.template
@@ -20,3 +20,7 @@ REFRESH_EVERY_SECONDS=5
 # The path of the file that will be refreshed at every REFRESH_EVERY_SECONDS
 # containing the instant stats.
 STATS_FILE=/usr/share/nginx/html/stats.txt
+
+# The path of the FIFO pipe where the monitoring output will be sent. Defaults
+# to a custom file path that will be created if not present.
+FIFO_PATH=/tmp/userver_monitor


### PR DESCRIPTION
## Scope

- Updated `nginxproxy/nginx-proxy` docker image from `1.2-alpine` to `1.5-alpine`;
- Updated `nginxproxy/acme-companion` docker image from `2.2` to `2.3`;
- Updated `ferdn4ndo/docker-containers-monitor` docker image from `1.0.1` to `1.0.2` and the env template file;
- Updated `traefik/whoami` docker image from `1.8` to `1.10`;