### PR TITLE
chore: removing docker from dependabot ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,3 @@ updates:
     directory: /
     schedule:
       interval: weekly
-
-  - package-ecosystem: docker
-    directory: /
-    schedule:
-      interval: weekly


### PR DESCRIPTION
## Scope
- Removed `docker` from `dependabot` ecosystem as there is no Dockerfile in the repository;

## Checklist :rotating_light:
<!-- Check all items that apply. -->
- [x] My code follows the code style
- [x] Created all unit/e2e tests needed
- [x] All lints and tests passed correctly
- [x] I upgraded dependencies to the latest working version

:heart: Thank you!
