### PR TITLE
fix: GH deploy action subfolder

### DIFF
--- a/.github/actions/deploy_local/action.yml
+++ b/.github/actions/deploy_local/action.yml
@@ -78,7 +78,10 @@ runs:
       shell: bash
 
     - name: Try to run containers
-      run: >
+      env:
+        ROOT_WORK_DIR: "${{ inputs.root-work-dir }}"
+      run: |
+        cd "$ROOT_WORK_DIR"
         docker compose up --build --remove-orphans --detach --wait --wait-timeout 30
       shell: bash
 


### PR DESCRIPTION
## Scope
- Fixed the docker build command to run in a subfolder if specified;

## Checklist :rotating_light:
<!-- Check all items that apply. -->
- [x] My code follows the code style
- [x] Created all unit/e2e tests needed
- [x] All lints and tests passed correctly
- [x] I upgraded dependencies to the latest working version

:heart: Thank you!
